### PR TITLE
Fix terraform EOF bug

### DIFF
--- a/lib/services/terraform.js
+++ b/lib/services/terraform.js
@@ -138,8 +138,8 @@ class Terraform {
             const key = first(Object.keys(row));
             const value = row[key];
             const serializedValue = isString(value) && value.substr(0, 5) == "<<EOF" ? value : JSON.stringify(value);
-            return `${key} = ${serializedValue}`;
-        }).join("\n");
+            return `${key} = ${serializedValue}\n`;
+        }).join("");
     }
 
     async writeTerraformVariablesFile({ cloud, keys }) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbs-network/polygon",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Polygon is a tool to provision new Orbs Hybrid Blockchain nodes",
   "main": "index.js",
   "scripts": {

--- a/test/unit/terraform-tests.js
+++ b/test/unit/terraform-tests.js
@@ -157,7 +157,8 @@ s3_bucket_name = "boyar-mumbai-node4"
 s3_boyar_key = "boyar/config.json"
 s3_boyar_config_url = "https://s3-ap-south-1.amazonaws.com/boyar-mumbai-node4/boyar/config.json"
 ethereum_endpoint = "http://eth.orbs.com"
-ethereum_topology_contract_address = "0xa8Ef7740D85B1c0c22E39aae896e829Af7c895A5"`);
+ethereum_topology_contract_address = "0xa8Ef7740D85B1c0c22E39aae896e829Af7c895A5"
+`);
         });
     })
 });


### PR DESCRIPTION
For some reason `terraform.tfvars` treats multi line string differently unless the terminating `EOF` is followed by a new line.