### PR TITLE
Fix supervisorctl restart problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbs-network/polygon",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Polygon is a tool to provision new Orbs Hybrid Blockchain nodes",
   "main": "index.js",
   "scripts": {

--- a/resources/terraform/aws/swarm-manager.tf
+++ b/resources/terraform/aws/swarm-manager.tf
@@ -157,6 +157,8 @@ export BOYAR_WRAPPER_PATH=/opt/orbs/boyar.sh
 cat <<-EOF > $BOYAR_WRAPPER_PATH
 #!/bin/bash
 
+trap "kill -- -$$" EXIT
+
 multilog_err=1
 multilog_cmd="multilog s16777215 n32 /var/efs/boyar-logs/"
 


### PR DESCRIPTION
Now `supervisorctl stop all` kills all processes that were spawned by `/opt/orbs/boyar.sh`